### PR TITLE
Add two styling classes

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs
@@ -1,7 +1,7 @@
 {{#if siteSettings.signatures_enabled}}
   <div class="control-group signatures">
     <label class="control-label">Enable Signatures</label>
-    <div class="controls">
+    <div class="controls bio-composer input-xxlarge">
       <label class='checkbox-label'>
         {{input type="checkbox" checked=model.custom_fields.see_signatures}}
           See user signatures below posts


### PR DESCRIPTION
I noticed an issue first on mobile. The signature editor was quite wonky. I found that if you add the classes that are present for the About Me editor ("bio-composer" and "input-xxlarge"), the CSS handles the rest and it styles things much nicer on both mobile and desktop. Let me know if you need any extra info!