### PR TITLE
Update GitHub link and correct CSS classes

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs
@@ -1,7 +1,7 @@
 {{#if siteSettings.signatures_enabled}}
   <div class="control-group signatures">
     <label class="control-label">Enable Signatures</label>
-    <div class="controls bio-composer input-xxlarge">
+    <div class="controls">
       <label class='checkbox-label'>
         {{input type="checkbox" checked=model.custom_fields.see_signatures}}
           See user signatures below posts
@@ -10,7 +10,7 @@
   </div>
   <div class="control-group signatures">
     <label class="control-label">My Signature</label>
-    <div class="controls">
+    <div class="controls bio-composer input-xxlarge">
       {{#if siteSettings.signatures_advanced_mode}}
         {{d-editor value=model.custom_fields.signature_raw showUploadModal="showUploadModal"}}
       {{else}}

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 # about: A plugin to get that nostalgia signatures in Discourse Foruns
 # version: 2.0.0
 # author: Rafael Silva <xfalcox@gmail.com>
-# url: https://github.com/xfalcox/discourse-signatures
+# url: https://github.com/discourse/discourse-signatures
 
 enabled_site_setting :signatures_enabled
 


### PR DESCRIPTION
Just a couple of minor fixes. I updated the GitHub link to point to the official Discourse fork. The CSS fixes the classes that were added by me, but accidentally added to the wrong element.