### PR TITLE
FIX: Remove register_asset call for `.hbs` file

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -57,5 +57,4 @@ after_initialize do
   end
 end
 
-register_asset "javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs"
 register_asset "stylesheets/common/signatures.scss"


### PR DESCRIPTION
Files in the `assets/javascripts` directory are automatically compiled, so this was introducing a duplicate. In the latest version of Discourse this also triggers a build error