### PR TITLE
UX: adds a placeholder for signature input

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs
@@ -10,21 +10,18 @@
   </div>
   <div class="control-group signatures">
     <label class="control-label">{{i18n "signatures.my_signature"}}</label>
-    <div class="controls bio-composer input-xxlarge">
-      {{#if siteSettings.signatures_advanced_mode}}
-        <DEditor
-          @value={{model.custom_fields.signature_raw}}
-          @showUploadModal="showUploadModal"
-        />
-      {{else}}
-        <label class="text-label">
-          <Input
-            @type="text"
-            class="input-xxlarge"
-            @value={{model.custom_fields.signature_url}}
-          />
-        </label>
-      {{/if}}
-    </div>
+    {{#if siteSettings.signatures_advanced_mode}}
+      <DEditor
+        @value={{model.custom_fields.signature_raw}}
+        @showUploadModal="showUploadModal"
+      />
+    {{else}}
+      <Input
+        @type="text"
+        class="input-xxlarge"
+        placeholder={{i18n "signatures.signature_placeholder"}}
+        @value={{model.custom_fields.signature_url}}
+      />
+    {{/if}}
   </div>
 {{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,3 +4,4 @@ en:
       enable_signatures: "Enable Signatures"
       show_signatures: "See user signatures below posts"
       my_signature: "My Signature"
+      signature_placeholder: "A valid URL to an image"


### PR DESCRIPTION
The placeholder makes it clear that the field expects an URL.
Also removes an un-necessary wrapping div.

Before:

![Screenshot 2024-07-24 at 21 30 39](https://github.com/user-attachments/assets/4d649121-e0f4-41af-b083-d1191c55eb19)

After:

![Screenshot 2024-07-24 at 21 30 17](https://github.com/user-attachments/assets/2ba98244-acd8-428b-97c9-306b783fa923)
