### PR TITLE
DEV: Allow a longer signature

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -16,7 +16,7 @@ DiscoursePluginRegistry.serialized_current_user_fields << "signature_raw"
 after_initialize do
   register_user_custom_field_type("see_signatures", :boolean)
   register_user_custom_field_type("signature_url", :string, max_length: 32_000)
-  register_user_custom_field_type("signature_raw", :string, max_length: 1000)
+  register_user_custom_field_type("signature_raw", :string, max_length: 10_000)
 
   # add to class and serializer to allow for default value for the setting
   add_to_class(:user, :see_signatures) do


### PR DESCRIPTION
Bumping the custom user field `signature_raw` from 1000 -> 10000, as we've just met with this scenario where a user cannot be saved because of this limit.