### PR TITLE
DEV: Connecting to external URLs causes tests to hang

### DIFF
--- a/spec/system/image_signatures_spec.rb
+++ b/spec/system/image_signatures_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Image signatures", type: :system do
   fab!(:user)
   fab!(:topic) { Fabricate(:topic, category: Fabricate(:category)) }
   fab!(:post) { Fabricate(:post, topic:) }
-  let(:signature_image_url) { "https://example.com/signature.png" }
+  let(:signature_image_url) { "data:abcdef," }
 
   context "when signatures plugin is enabled" do
     before do


### PR DESCRIPTION
Using an external URL was causing the browser to actually attempt to
connect to it. Sometimes, a response from the external URL will take
more than 30 seconds to return a response causing the page to never fire
the load event before playwright's timeout is reached.

Example failure:

```
Failure/Error: measurement = Benchmark.measure { example.run }

Playwright::TimeoutError:
  Timeout 30000ms exceeded.
  Call log:
    - navigating to "http://localhost:31338/t/this-is-a-test-topic-0/1/2", waiting until "load"
```
